### PR TITLE
Organized the test features in a better way & added a bash script to …

### DIFF
--- a/.env
+++ b/.env
@@ -19,7 +19,6 @@ MONGO_URL=mongodb://admin:adminpassword@mongo-nass:27017/NASS?authsource=admin
 
 AUTH_API_URL=http://auth-api-1:3000/test
 
-ENABLE_TEST_MODE=true
 AUTH_PORT=3000
 CUSTOMER_PORT=3001
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   mongo-nass:
     image: mongo:latest
     restart: always
+    profiles: ["mongo-nass"]
     container_name: mongo-nass
     hostname: mongo-nass
     ports:
@@ -36,6 +37,7 @@ services:
   auth-api:
     build: ./
     restart: always
+    profiles: ["auth-api"]
     container_name: auth-api-1
     environment:
       - AUTH_API_PORT=3000
@@ -58,9 +60,12 @@ services:
         limits:
           cpus: '1.5'
           memory: 512M
+
+        
   mongo-express:
     image: mongo-express
     container_name: mongo-express
+    profiles: ["mongo-express"]
     ports:
       - "8081:8081"
     expose:
@@ -83,7 +88,8 @@ services:
 
   global-tests:
     build: ./
-    command: npm test
+    profiles: ["test-global"]
+    command: npm run test-global
     depends_on:
       - auth-api
       - mongo-nass

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test-scv": "jest scv.test.ts --runInBand --no-cache",
-    "test-ssv": "jest ssv.test.ts --runInBand --no-cache",
-    "test": "jest global.test.ts --runInBand --no-cache --verbose"
+    "test-global": "jest global.test.ts --runInBand --no-cache --verbose"
   },
   "author": "",
   "license": "ISC",

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+
+TEST_PARAMETER=$1
+
+
+if [ "$TEST_PARAMETER" = "no-test" ]; then
+    COMPOSE_PROFILES="mongo-nass,auth-api,mongo-express,test-global" docker compose down -v
+    COMPOSE_PROFILES="mongo-nass,auth-api,mongo-express" docker compose up -d
+else
+    if [ "$TEST_PARAMETER" = "global" ]; then
+        COMPOSE_PROFILES="mongo-nass,auth-api,mongo-express,test-global" docker compose up -d
+    else
+        echo "Unknown test parameter. Please use 'no-test' or 'run-test'."
+        bash
+    fi
+fi
+
+

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -22,14 +22,11 @@ const waitForServer = async (url: string, timeout = 20000) => {
 };
 
 module.exports = async () => {
-    if (process.env.ENABLE_TEST_MODE !== 'true') {
-        console.log('Test mode is disabled. Skipping setup.');
-        return;
-    } else {
-        const appUrl = process.env.AUTH_API_URL || "http://localhost:3000/test";
-        if (!appUrl) {
-            throw new Error("AUTH_API_URL is not set. Please set it in your environment variables.");
-        }
-        await waitForServer(appUrl);
+
+    const appUrl = process.env.AUTH_API_URL || "http://localhost:3000/test";
+    if (!appUrl) {
+        throw new Error("AUTH_API_URL is not set. Please set it in your environment variables.");
     }
+    await waitForServer(appUrl);
+
 };


### PR DESCRIPTION
## Testing features
Before this merge, the tests were automatically run anytime the container would've been up.
Now, the container has to be started with the `./run.sh` command, with different parameters:
* `no-test` : for the container to be loaded with no tests (not recommended for production)
* `global` : for the global tests to be ran

More tests are coming for every step of the project. 